### PR TITLE
Fix repo does not exist

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -137,7 +137,7 @@ func scan(folder string) {
 		log.Fatal(err)
 	}
 	filePath := getDotFilePath()
-	addNewSliceElementsToFile(filePath, repositories)
+	dumpStringsSliceToFile(repositories, filePath)
 }
 
 func createFileIfNotExist(fileName string) error {

--- a/scan.go
+++ b/scan.go
@@ -81,26 +81,6 @@ func parseFileLinesToSlice(filePath string) ([]string, error) {
 	return lines, nil
 }
 
-func sliceContains(slice []string, value string) bool {
-	for _, v := range slice {
-		if v == value {
-			return true
-		}
-	}
-	return false
-}
-
-// joinSlices adds the element of the `new` slice
-// into the `existing` slice, only if not already there
-func joinSlices(new []string, existing []string) []string {
-	for _, i := range new {
-		if !sliceContains(existing, i) {
-			existing = append(existing, i)
-		}
-	}
-	return existing
-}
-
 // dumpStringsSliceToFile writes content to the file in path `filePath` (overwriting existing content)
 func dumpStringsSliceToFile(lines []string, filePath string) error {
 	// Join the strings into a single string with newline separators
@@ -113,17 +93,6 @@ func dumpStringsSliceToFile(lines []string, filePath string) error {
 	}
 
 	return nil
-}
-
-// addNewSliceElementsToFile given a slice of strings representing paths, stores them
-// to the filesystem
-func addNewSliceElementsToFile(filePath string, newRepos []string) {
-	existingRepos, err := parseFileLinesToSlice(filePath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	repos := joinSlices(newRepos, existingRepos)
-	dumpStringsSliceToFile(repos, filePath)
 }
 
 // scan scans a new folder for Git repositories


### PR DESCRIPTION
This pull request fixes the `repository does not exist` bug. 
Previously, when saving the repository paths to the `.gogitlocalstats` file, the tool would retrieve the existing paths from the file and add them to the list of paths. However, this step was unnecessary and led to the bug where removed repository paths were still included, causing unexpected panics.

In this pull request, I have addressed the issue by modifying the code logic. Now, when saving the paths to the file, the tool directly writes the paths from the slice without adding the existing paths from the file. This change ensures that only the current and valid repository paths are saved to the `.gogitlocalstats` file.

This solution eliminates the unnecessary step of adding existing paths and prevents the occurrence of panics when accessing non-existent repositories.