### PR TITLE
Fix out of range

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"log"
 	"sort"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 const outOfRange = 99999
@@ -256,6 +257,9 @@ func printCells(cols map[int]column) {
 			if col, ok := cols[i]; ok {
 				//special case today
 				if i == 0 && j == calcOffset()-1 {
+					if len(col) >= j {
+						continue
+					}
 					printCell(col[j], true)
 					continue
 				} else {


### PR DESCRIPTION
Hi!
I wanted to use this tool, so I fixed the error! The fix might be a little subtle...

There was an error as shown below.
```console
~/github.com/ddddddO/local-git-contributions-visualizer
14:13:45 > cat /home/ochi/.gogitlocalstats
/home/ochi/github.com/ddddddO/gtree~/github.com/ddddddO/local-git-contributions-visualizer
14:13:48 > go run *.go -email lbfdeatq@gmail.com

                         Jan             Feb             Mar             Apr                 May             Jun
       -   -   -   -   -   -   -   1   -   -   2   -   -   -   -   -   -   -   -   -   -   -   -   -   -   2   - panic: runtime error: index out of range [6] with length 6

goroutine 1 [running]:
main.printCells(0xc0000188f0?)
        /home/ochi/github.com/ddddddO/local-git-contributions-visualizer/stats.go:259 +0x165
main.printCommitsStats(0x772fe0?)
        /home/ochi/github.com/ddddddO/local-git-contributions-visualizer/stats.go:29 +0x35f
main.stats({0x7ffe3224d3f0?, 0xc00009a160?})
        /home/ochi/github.com/ddddddO/local-git-contributions-visualizer/stats.go:22 +0x48
main.main()
        /home/ochi/github.com/ddddddO/local-git-contributions-visualizer/main.go:18 +0x176
exit status 2
```

After modification, as shown below, it was able to run!
```console
~/github.com/ddddddO/local-git-contributions-visualizer
14:14:30 > go run *.go -email lbfdeatq@gmail.com

                         Jan             Feb             Mar             Apr                 May             Jun
       -   -   -   -   -   -   -   1   -   -   2   -   -   -   -   -   -   -   -   -   -   -   -   -   -   2   -
 Fri   -   -   -   -   4   -   -   6   1   3   -   -   -   -   -   -   -   -   -   -   -   -   -   1   -   -   -   -
       -   -   -   -   -   -   -   -   3   -   -   -   -   -   -   -   -   -   -   -   -   1   -   -   -   -   -   -
 Wed   -   -   -   -   -   -   -   3   1   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
       -   -   -   -   -   1   -   -   -   1   -   4   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
 Mon   -   -   -   -   1   -   -   7   3   -   3   -   -   -   -   -   -   -   1   -   -   -   -   -   -   2   4   -
       -   -   -   2   -   -   -   9   2   7   1   -   -   -   -   -   -   -   -   -   -   3   -   -   1   -   9
```

Below is an overall view of the terminal.
![local-git](https://github.com/abdullah-alaadine/local-git-contributions-visualizer/assets/41510086/2f52b615-b146-4dce-88cd-2dec02a616e2)
