### PR TITLE
return the collected repos instead of writing to a file

### DIFF
--- a/fileutils.go
+++ b/fileutils.go
@@ -5,37 +5,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/gookit/color"
 )
-
-func deleteFile(fileName, filePath string) error {
-	err := os.Remove(filepath.Join(filePath, fileName))
-	if err != nil {
-		return fmt.Errorf("failed to delete %s file: %s", fileName, err)
-	}
-
-	return nil
-}
-
-func createFileIfNotExist(fileName string, dir string) error {
-
-	filePath := filepath.Join(dir, fileName)
-
-	// Check if the file exists
-	_, err := os.Stat(filePath)
-	if os.IsNotExist(err) {
-		// Create the file if it doesn't exist
-		_, err := os.Create(filePath)
-		if err != nil {
-			return fmt.Errorf("failed to create file: %s", err)
-		}
-	}
-
-	return nil
-}
 
 func isValidFolderPath(folder string) bool {
 	// Check if the folder exists and is a directory

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -15,16 +14,9 @@ func main() {
 	s.FinalMSG = "Done!"
 	s.Start()
 
-	if folder != "" {
-		scan(folder)
-	}
+	repos := scan(folder)
 
-	stats(email, statsType)
+	stats(email, statsType, repos)
 
 	s.Stop()
-	// There is no need to handle the errors, it is okay to keep the file in the home dir
-	homeDir, err := os.UserHomeDir()
-	if err == nil {
-		deleteFile(".gogitlocalstats", homeDir)
-	}
 }

--- a/scan.go
+++ b/scan.go
@@ -1,34 +1,20 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/gookit/color"
 )
 
-func getDotFilePath() string {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal(color.Red.Sprintf("Error: %v\n", err))
-	}
-
-	dotFile := usr.HomeDir + "/.gogitlocalstats"
-
-	return dotFile
-}
-
 func scanGitFolders(root string) ([]string, error) {
 	var gitFolders []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			color.Red.Printf("Error accessing path %q: %v\n", path, err)
-			return nil
+			return err
 		}
 
 		if info.IsDir() && info.Name() == ".git" {
@@ -48,71 +34,15 @@ func scanGitFolders(root string) ([]string, error) {
 	if err != nil {
 		color.Red.Printf("Error walking the path %q: %v\n", root, err)
 		return nil, err
-	} else {
-		return gitFolders, nil
 	}
-}
-
-// parseFileLinesToSlice given a file path string, gets the content
-// of each line and parses it to a slice of strings.
-func parseFileLinesToSlice(filePath string) ([]string, error) {
-	// Open the file
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s", err)
-	}
-	defer file.Close()
-
-	// Create a scanner to read the file
-	scanner := bufio.NewScanner(file)
-
-	// Create a slice to store the lines
-	var lines []string
-
-	// Read each line of the file
-	for scanner.Scan() {
-		line := scanner.Text()
-		lines = append(lines, line)
-	}
-
-	// Check for any scanner errors
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error while scanning file: %s", err)
-	}
-
-	return lines, nil
-}
-
-// dumpStringsSliceToFile writes content to the file in path `filePath` (overwriting existing content)
-func dumpStringsSliceToFile(lines []string, filePath string) error {
-	// Join the strings into a single string with newline separators
-	content := strings.Join(lines, "\n")
-
-	// Write the content to the file, overwriting the existing content
-	err := os.WriteFile(filePath, []byte(content), 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write file: %s", err)
-	}
-
-	return nil
+	return gitFolders, nil
 }
 
 // scan scans a new folder for Git repositories
-func scan(folder string) {
-	// Get the user's home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(color.Red.Sprintf("Error: %v\n", err))
-	}
-
-	err = createFileIfNotExist(".gogitlocalstats", homeDir)
-	if err != nil {
-		log.Fatal(color.Red.Sprintf("Error: %v\n", err))
-	}
+func scan(folder string) []string {
 	repositories, err := scanGitFolders(folder)
 	if err != nil {
 		log.Fatal(color.Red.Sprintf("Error: %v\n", err))
 	}
-	filePath := getDotFilePath()
-	dumpStringsSliceToFile(repositories, filePath)
+	return repositories
 }

--- a/stats.go
+++ b/stats.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
@@ -21,8 +20,8 @@ type column []int
 var graphData []float64
 
 // stats calculates and prints the stats.
-func stats(email string, statsType string) {
-	commits := processRepositories(email)
+func stats(email string, statsType string, repos []string) {
+	commits := processRepositories(email, repos)
 	fmt.Println()
 	switch statsType {
 	case "Table":
@@ -149,12 +148,7 @@ func calcOffset() int {
 
 // processRepositories given a user email, returns the
 // commits made in the last 6 months
-func processRepositories(email string) map[int]int {
-	filePath := getDotFilePath()
-	repos, err := parseFileLinesToSlice(filePath)
-	if err != nil {
-		log.Fatal(color.Red.Sprint(err))
-	}
+func processRepositories(email string, repos []string) map[int]int {
 	daysInMap := daysInLastSixMonths
 
 	commits := make(map[int]int, daysInMap)
@@ -162,6 +156,7 @@ func processRepositories(email string) map[int]int {
 		commits[i] = 0
 	}
 
+	var err error
 	for _, path := range repos {
 		commits, err = fillCommits(email, path, commits)
 		if err != nil {
@@ -208,7 +203,7 @@ func buildCols(keys []int, commits map[int]int) map[int]column {
 	col := column{}
 
 	for _, k := range keys {
-		week := int(k / 7) // 26, 25...1
+		week := k / 7      // 26, 25...1
 		dayinweek := k % 7 // 0, 1, 2, 3, 4, 5, 6
 
 		if dayinweek == 0 { // reset
@@ -231,7 +226,7 @@ func printCell(val int, today bool) {
 	var colorFunc color.Style
 	if today {
 		colorFunc = color.New(color.FgBlack, color.BgRed)
-		colorFunc.Printf("%2d", val)
+		colorFunc.Printf("%3d", val)
 	} else if val == 0 {
 		colorFunc = color.New(color.FgWhite, color.BgBlack)
 		colorFunc.Print(" - ")


### PR DESCRIPTION
The way this tool was working is to collect the git repositories paths, and write them into a file, 
so that other parts of the code can read these in any time.
This PR removes the file related code, and to just return the collected repos from the `scan` function, in order to pass the returned value to `stats` function.